### PR TITLE
Melhorar performance

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -4,8 +4,8 @@ const cellSize = 5
 const canvas = document.querySelector('canvas')
 const ctx = canvas.getContext('2d', { alpha: false })
 const dpr = window.devicePixelRatio || 1
-let lastColor
 const boundsOffset = 5
+let currentColor
 
 canvas.width = width * dpr
 canvas.height = height * dpr
@@ -21,17 +21,49 @@ const draw = (world) => {
   ctx.fillStyle = 'white'
   ctx.fillRect(0, boundingY, width, height - boundingY)
 
-  for (let {
-    x,
-    y,
-    cell: { color },
-  } of world.getActive()) {
-    if (lastColor !== color) {
+  const blocks = world.getActive()
+  const first = blocks.pop()
+
+  if (first === undefined) return
+
+  let color = first.cell.color
+  const rest = []
+
+  ctx.fillStyle = color
+
+  while (blocks.length + rest.length > 0) {
+    let block = blocks.pop()
+
+    if (block === undefined) {
+      block = rest.pop()
+      color = block.cell.color
       ctx.fillStyle = color
-      lastColor = color
     }
-    ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize)
+
+    if (block.cell.color === color) {
+      const { x, y } = block
+      ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize)
+    } else {
+      rest.push(block)
+    }
   }
 }
 
+const draw_ = (world) => {
+  const boundingY = world.getBoundingY() * cellSize - boundsOffset
+
+  ctx.fillStyle = 'white'
+  ctx.fillRect(0, boundingY, width, height - boundingY)
+
+  const blocks = world.getActive().sort((b) => b.cell.color)
+
+  for (let { x, y, cell } of blocks) {
+    if (currentColor !== cell.color) {
+      currentColor = cell.color
+      ctx.fillStyle = currentColor
+    }
+
+    ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize)
+  }
+}
 export { draw, cellSize }

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -4,7 +4,7 @@ const width = 500
 const height = 500
 const cellSize = 5
 const canvas = document.querySelector('canvas')
-const ctx = canvas.getContext('2d')
+const ctx = canvas.getContext('2d', { alpha: false })
 const dpr = window.devicePixelRatio || 1
 let lastColor
 
@@ -15,7 +15,8 @@ canvas.style.height = `${height}px`
 ctx.scale(dpr, dpr)
 
 const draw = (world) => {
-  ctx.clearRect(0, world.getBoundingY(), width, height)
+  ctx.fillStyle = 'white'
+  ctx.fillRect(0, world.getBoundingY(), width, height)
   world.forEach(drawCell)
 }
 

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -5,7 +5,6 @@ const canvas = document.querySelector('canvas')
 const ctx = canvas.getContext('2d', { alpha: false })
 const dpr = window.devicePixelRatio || 1
 const boundsOffset = 5
-let currentColor
 
 canvas.width = width * dpr
 canvas.height = height * dpr
@@ -21,49 +20,16 @@ const draw = (world) => {
   ctx.fillStyle = 'white'
   ctx.fillRect(0, boundingY, width, height - boundingY)
 
-  const blocks = world.getActive()
-  const first = blocks.pop()
+  const activeCells = world.getActive()
 
-  if (first === undefined) return
+  for (let color in activeCells) {
+    ctx.fillStyle = color
+    const blocks = activeCells[color]
 
-  let color = first.cell.color
-  const rest = []
-
-  ctx.fillStyle = color
-
-  while (blocks.length + rest.length > 0) {
-    let block = blocks.pop()
-
-    if (block === undefined) {
-      block = rest.pop()
-      color = block.cell.color
-      ctx.fillStyle = color
-    }
-
-    if (block.cell.color === color) {
-      const { x, y } = block
+    for (let { x, y } of blocks) {
       ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize)
-    } else {
-      rest.push(block)
     }
   }
 }
 
-const draw_ = (world) => {
-  const boundingY = world.getBoundingY() * cellSize - boundsOffset
-
-  ctx.fillStyle = 'white'
-  ctx.fillRect(0, boundingY, width, height - boundingY)
-
-  const blocks = world.getActive().sort((b) => b.cell.color)
-
-  for (let { x, y, cell } of blocks) {
-    if (currentColor !== cell.color) {
-      currentColor = cell.color
-      ctx.fillStyle = currentColor
-    }
-
-    ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize)
-  }
-}
 export { draw, cellSize }

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -15,10 +15,15 @@ ctx.fillStyle = 'white'
 ctx.fillRect(0, 0, width, height)
 
 const draw = (world) => {
-  const boundingY = world.getBoundingY() * cellSize - boundsOffset
+  const boundingY = world.getUpperBound() * cellSize - boundsOffset
 
   ctx.fillStyle = 'white'
   ctx.fillRect(0, boundingY, width, height - boundingY)
+
+  if (window.DEBUG) {
+    ctx.fillStyle = 'red'
+    ctx.fillRect(0, boundingY, width, 1)
+  }
 
   const activeCells = world.getActive()
 
@@ -30,6 +35,8 @@ const draw = (world) => {
       ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize)
     }
   }
+
+  world.refreshUpperBound()
 }
 
 export { draw, cellSize }

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -1,5 +1,3 @@
-import * as air from './elements/air'
-
 const width = 500
 const height = 500
 const cellSize = 5
@@ -7,35 +5,33 @@ const canvas = document.querySelector('canvas')
 const ctx = canvas.getContext('2d', { alpha: false })
 const dpr = window.devicePixelRatio || 1
 let lastColor
+const boundsOffset = 5
 
 canvas.width = width * dpr
 canvas.height = height * dpr
 canvas.style.width = `${width}px`
 canvas.style.height = `${height}px`
 ctx.scale(dpr, dpr)
+ctx.fillStyle = 'white'
+ctx.fillRect(0, 0, width, height)
 
 const draw = (world) => {
+  const boundingY = world.getBoundingY() * cellSize - boundsOffset
+
   ctx.fillStyle = 'white'
-  ctx.fillRect(0, world.getBoundingY(), width, height)
-  world.forEach(drawCell)
-}
+  ctx.fillRect(0, boundingY, width, height - boundingY)
 
-const drawCell = (x, y, cell) => {
-  switch (cell.type) {
-    case air.NAME:
-      break
-    default:
-      drawRect(x, y, cell)
-      break
+  for (let {
+    x,
+    y,
+    cell: { color },
+  } of world.getActive()) {
+    if (lastColor !== color) {
+      ctx.fillStyle = color
+      lastColor = color
+    }
+    ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize)
   }
-}
-
-const drawRect = (x, y, { color }) => {
-  if (lastColor !== color) {
-    ctx.fillStyle = color
-    lastColor = color
-  }
-  ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize)
 }
 
 export { draw, cellSize }

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -6,6 +6,7 @@ const cellSize = 5
 const canvas = document.querySelector('canvas')
 const ctx = canvas.getContext('2d')
 const dpr = window.devicePixelRatio || 1
+let lastColor
 
 canvas.width = width * dpr
 canvas.height = height * dpr
@@ -14,7 +15,7 @@ canvas.style.height = `${height}px`
 ctx.scale(dpr, dpr)
 
 const draw = (world) => {
-  ctx.clearRect(0, 0, width, height)
+  ctx.clearRect(0, world.getBoundingY(), width, height)
   world.forEach(drawCell)
 }
 
@@ -28,8 +29,11 @@ const drawCell = (x, y, cell) => {
   }
 }
 
-const drawRect = (x, y, cell) => {
-  ctx.fillStyle = cell.color
+const drawRect = (x, y, { color }) => {
+  if (lastColor !== color) {
+    ctx.fillStyle = color
+    lastColor = color
+  }
   ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize)
 }
 

--- a/src/element.js
+++ b/src/element.js
@@ -1,4 +1,4 @@
-const rand = (max, min = 0) => Math.random() * (max - min) + min
+import { randInt } from './random'
 
 const make = ({ type, color, ...meta }) => ({
   type,
@@ -9,7 +9,7 @@ const make = ({ type, color, ...meta }) => ({
 })
 
 const createColor = (color) =>
-  `hsl(${color[0]}deg ${color[1]}% ${rand(color[2], color[3]).toFixed(1)}%)`
+  `hsl(${color[0]}deg ${color[1]}% ${randInt(color[2], color[3])}%)`
 
 const updateColor = (cell) => {
   cell.color = createColor(cell.colorInput)

--- a/src/element.js
+++ b/src/element.js
@@ -9,7 +9,7 @@ const make = ({ type, color, ...meta }) => ({
 })
 
 const createColor = (color) =>
-  `hsl(${color[0]}deg ${color[1]}% ${rand(color[2], color[3])}%)`
+  `hsl(${color[0]}deg ${color[1]}% ${rand(color[2], color[3]).toFixed(1)}%)`
 
 const updateColor = (cell) => {
   cell.color = createColor(cell.colorInput)

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import * as smoke from './elements/smoke'
 import * as wood from './elements/wood'
 
 const DEBUG = false
+const MAX_FPS = 60
 
 const tick = () => {
   world.update()
@@ -15,8 +16,21 @@ const tick = () => {
 }
 
 const loop = () => {
-  tick()
   requestAnimationFrame(loop)
+  now = Date.now()
+  elapsed = now - then
+
+  if (elapsed > fpsInterval) {
+    then = now - (elapsed % fpsInterval)
+    tick()
+  }
+}
+
+const start = () => {
+  fpsInterval = 1000 / MAX_FPS
+  then = Date.now()
+  startTime = then
+  loop()
 }
 
 const $canvas = document.querySelector('#canvas')
@@ -94,7 +108,7 @@ document.querySelector('#tick').addEventListener('click', tick)
 world.init()
 
 if (!DEBUG) {
-  loop()
+  start()
 }
 
 window.loop = loop

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import * as water from './elements/water'
 import * as smoke from './elements/smoke'
 import * as wood from './elements/wood'
 
-const DEBUG = false
+window.DEBUG = false
 const MAX_FPS = 60
 
 const tick = () => {
@@ -107,7 +107,7 @@ document.querySelector('#tick').addEventListener('click', tick)
 
 world.init()
 
-if (!DEBUG) {
+if (!window.DEBUG) {
   start()
 }
 

--- a/src/world.js
+++ b/src/world.js
@@ -9,11 +9,15 @@ let cells = []
 let size = 0
 let generation
 let boundingY
+let upperBound
+let defaultUpperBound
 let activeCells
 
 const init = (newSize = 100) => {
   generation = 1
   boundingY = newSize
+  defaultUpperBound = { x: 0, y: newSize }
+  upperBound = defaultUpperBound
   size = newSize
   cells = Array.from({ length: size * size }, () => air.make())
 }
@@ -37,7 +41,7 @@ const draw = (x, y, cell) => {
     const index = getIndex(x, y)
     cell.clock = generation
     cells[index] = cell
-    if (y < boundingY) boundingY = y
+    if (y < upperBound.y) upperBound = { x, y }
   }
 }
 
@@ -45,7 +49,7 @@ const set = (x, y, cell) => {
   const index = getIndex(x, y)
   cell.clock = generation + 1
   cells[index] = cell
-  if (y < boundingY) boundingY = y
+  if (y < upperBound.y) upperBound = { x, y }
 }
 
 const is = (x, y, type) => get(x, y).type === type
@@ -82,7 +86,6 @@ const api = {
 
 const update = () => {
   activeCells = {}
-  boundingY = size
 
   for (let i = 0, l = cells.length; i < l; i++) {
     const [x, y] = getCoords(i)
@@ -90,9 +93,9 @@ const update = () => {
 
     if (cell.type !== 'AIR') {
       if (cell.color in activeCells) {
-        activeCells[cell.color].push({ x, y })
+        activeCells[cell.color].push({ x, y, cell })
       } else {
-        activeCells[cell.color] = [{ x, y }]
+        activeCells[cell.color] = [{ x, y, cell }]
       }
     }
 
@@ -118,8 +121,23 @@ const update = () => {
   generation++
 }
 
-const getBoundingY = () => boundingY
+const getUpperBound = () => upperBound.y
+
+const refreshUpperBound = () => {
+  if (is(upperBound.x, upperBound.y, 'AIR')) {
+    upperBound = defaultUpperBound
+  }
+}
 
 const getActive = () => activeCells
 
-export { init, getBoundingY, get, draw, update, print, getActive }
+export {
+  init,
+  getUpperBound,
+  refreshUpperBound,
+  get,
+  draw,
+  update,
+  print,
+  getActive,
+}

--- a/src/world.js
+++ b/src/world.js
@@ -14,7 +14,6 @@ let activeCells
 const init = (newSize = 100) => {
   generation = 1
   boundingY = newSize
-  activeCells = []
   size = newSize
   cells = Array.from({ length: size * size }, () => air.make())
 }
@@ -82,12 +81,21 @@ const api = {
 }
 
 const update = () => {
-  activeCells = []
+  activeCells = {}
   boundingY = size
+
   for (let i = 0, l = cells.length; i < l; i++) {
     const [x, y] = getCoords(i)
     const cell = cells[i]
-    if (cell.type !== 'AIR') activeCells.push({ x, y, cell })
+
+    if (cell.type !== 'AIR') {
+      if (cell.color in activeCells) {
+        activeCells[cell.color].push({ x, y })
+      } else {
+        activeCells[cell.color] = [{ x, y }]
+      }
+    }
+
     switch (cell.type) {
       case 'AIR':
         break

--- a/src/world.js
+++ b/src/world.js
@@ -13,7 +13,7 @@ let activeCells
 
 const init = (newSize = 100) => {
   generation = 1
-  boundingY = 0
+  boundingY = newSize
   activeCells = []
   size = newSize
   cells = Array.from({ length: size * size }, () => air.make())
@@ -83,6 +83,7 @@ const api = {
 
 const update = () => {
   activeCells = []
+  boundingY = size
   for (let i = 0, l = cells.length; i < l; i++) {
     const [x, y] = getCoords(i)
     const cell = cells[i]
@@ -111,10 +112,6 @@ const update = () => {
 
 const getBoundingY = () => boundingY
 
-const forEach = (f) => {
-  for (let { x, y, cell } of activeCells) {
-    f(x, y, cell)
-  }
-}
+const getActive = () => activeCells
 
-export { init, getBoundingY, get, draw, update, print, forEach }
+export { init, getBoundingY, get, draw, update, print, getActive }

--- a/src/world.js
+++ b/src/world.js
@@ -5,16 +5,18 @@ import * as stone from './elements/stone'
 import * as smoke from './elements/smoke'
 import * as wood from './elements/wood'
 
-let state = []
+let cells = []
 let size = 0
 let generation
 let boundingY
+let activeCells
 
 const init = (newSize = 100) => {
   generation = 1
   boundingY = 0
+  activeCells = []
   size = newSize
-  state = Array.from({ length: size * size }, () => air.make())
+  cells = Array.from({ length: size * size }, () => air.make())
 }
 
 const getIndex = (x, y) => x * size + y
@@ -28,20 +30,22 @@ const getCoords = (index) => {
 
 const get = (x, y) => {
   if (x < 0 || y < 0 || x >= size || y >= size) return { type: 'BOUNDS' }
-  return state[getIndex(x, y)]
+  return cells[getIndex(x, y)]
 }
 
 const draw = (x, y, cell) => {
   if (cell.type === air.NAME || is(x, y, air.NAME) || is(x, y, water.NAME)) {
+    const index = getIndex(x, y)
     cell.clock = generation
-    state[getIndex(x, y)] = cell
+    cells[index] = cell
     if (y < boundingY) boundingY = y
   }
 }
 
 const set = (x, y, cell) => {
+  const index = getIndex(x, y)
   cell.clock = generation + 1
-  state[getIndex(x, y)] = cell
+  cells[index] = cell
   if (y < boundingY) boundingY = y
 }
 
@@ -78,9 +82,11 @@ const api = {
 }
 
 const update = () => {
-  for (let i = 0, l = state.length; i < l; i++) {
+  activeCells = []
+  for (let i = 0, l = cells.length; i < l; i++) {
     const [x, y] = getCoords(i)
-    const cell = state[i]
+    const cell = cells[i]
+    if (cell.type !== 'AIR') activeCells.push({ x, y, cell })
     switch (cell.type) {
       case 'AIR':
         break
@@ -106,9 +112,7 @@ const update = () => {
 const getBoundingY = () => boundingY
 
 const forEach = (f) => {
-  for (let i = 0, l = state.length; i < l; i++) {
-    const [x, y] = getCoords(i)
-    const cell = state[i]
+  for (let { x, y, cell } of activeCells) {
     f(x, y, cell)
   }
 }

--- a/src/world.js
+++ b/src/world.js
@@ -8,9 +8,11 @@ import * as wood from './elements/wood'
 let state = []
 let size = 0
 let generation
+let boundingY
 
 const init = (newSize = 100) => {
   generation = 1
+  boundingY = 0
   size = newSize
   state = Array.from({ length: size * size }, () => air.make())
 }
@@ -33,12 +35,14 @@ const draw = (x, y, cell) => {
   if (cell.type === air.NAME || is(x, y, air.NAME) || is(x, y, water.NAME)) {
     cell.clock = generation
     state[getIndex(x, y)] = cell
+    if (y < boundingY) boundingY = y
   }
 }
 
 const set = (x, y, cell) => {
   cell.clock = generation + 1
   state[getIndex(x, y)] = cell
+  if (y < boundingY) boundingY = y
 }
 
 const is = (x, y, type) => get(x, y).type === type
@@ -99,6 +103,8 @@ const update = () => {
   generation++
 }
 
+const getBoundingY = () => boundingY
+
 const forEach = (f) => {
   for (let i = 0, l = state.length; i < l; i++) {
     const [x, y] = getCoords(i)
@@ -107,4 +113,4 @@ const forEach = (f) => {
   }
 }
 
-export { init, get, draw, update, print, forEach }
+export { init, getBoundingY, get, draw, update, print, forEach }


### PR DESCRIPTION
- Limitar em 60 FPS
- Diminuir a variedade de cores
- Desabilitar transparencia do canvas
- Limpar a tela apenas onde estão celulas ativas
- Agrupar celulas por cor